### PR TITLE
Use the current GlobalOffsetSeconds when initializing ThemePrefs

### DIFF
--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -191,7 +191,7 @@ local SL_CustomPrefs =
 	DefaultGlobalOffsetSeconds = {
 		-- The default value should not make it to gameplay, set to something nice
 		-- and easy to notice in case it goes wrong.
-		Default = 6.969
+		Default = PREFSMAN:GetPreference("GlobalOffsetSeconds")
 	}
 }
 

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -185,12 +185,10 @@ local SL_CustomPrefs =
 	-- Default Global Offset.
 	-- If players manipulate Global Offset via Advanced Options, return to this
 	-- value after their set is finished.
-	-- NOTE: changing this value here will have no effect. It's here to generate
-	-- the corresponding record in ThemePrefs.ini. The theme will manipulate the
-	-- value in ThemePrefs directly.
+	-- NOTE: this value will only be used when the corresponding ThemePrefs section
+	-- is initially generated. If it already exists, the theme will manipulate the
+	-- existing value in ThemePrefs directly.
 	DefaultGlobalOffsetSeconds = {
-		-- The default value should not make it to gameplay, set to something nice
-		-- and easy to notice in case it goes wrong.
 		Default = PREFSMAN:GetPreference("GlobalOffsetSeconds")
 	}
 }


### PR DESCRIPTION
Fixes #28

I got the `PREFSMAN:GetPreference("GlobalOffsetSeconds")` from UpdateDefaultGlobalOffset in SL-Helpers.lua, and from the tests I've done it works correctly.

- Deleted the theme section in ThemePrefs.ini
- Started SM5 with this theme set.
- Started a game and got to the Song Selection screen
- Went back to the Main Menu
- Checked ThemePrefs.ini: DefaultGlobalOffsetSeconds was set to my machine's offset instead of a very nice value.

I think I have made the PR correctly, but it's my first PR on Github so I might have missed something. I'll fix it if that's the case! ^^