### PR TITLE
Position score in gameplay

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/DifficultyMeter.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/DifficultyMeter.lua
@@ -2,7 +2,7 @@ local player = ...
 
 return Def.ActorFrame{
 	InitCommand=function(self)
-		self:xy( _screen.w-16, 16 )
+		self:xy( _screen.w-17, 16 )
 	end,
 
 	-- colored background for player's chart's difficulty meter

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/Score.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/Score.lua
@@ -27,9 +27,9 @@ return LoadFont("_wendy monospace numbers")..{
 	Name=pn.."Score",
 	InitCommand=function(self)
 		self:valign(1):halign(1)
-                self:zoom(Positions.ScreenGameplay.ScoreZoom())
-                self:x(Positions.ScreenGameplay.ScoreX(player))
-                self:y(Positions.ScreenGameplay.ScoreY())
+                self:zoom(0.3)
+                self:x(_screen.w-6)
+                self:y(40)
 	end,
 	JudgmentMessageCommand=function(self) self:queuecommand("RedrawScore") end,
 	RedrawScoreCommand=function(self)

--- a/Scripts/SL-Positions.lua
+++ b/Scripts/SL-Positions.lua
@@ -58,32 +58,6 @@ Positions.ScreenGameplay.ScoreZoom = function()
   end
 end
 
-Positions.ScreenGameplay.ScoreX = function(player)
-  if IsVerticalScreen() then return _screen.w - 8 end
-
-  if SL.Global.GameMode == "StomperZ" then
-    if player == PLAYER_1 then
-      return WideScale(160, 214)
-    else
-      return _screen.w - WideScale(50, 104)
-    end
-  else  -- Not StomperZ
-    if player == PLAYER_1 then
-      return _screen.cx - _screen.w/4.3
-    else
-      return _screen.cx + _screen.w/2.75
-    end
-  end
-end
-
-Positions.ScreenGameplay.ScoreY = function()
-  if SL.Global.GameMode == "StomperZ" then
-    return 20
-  else
-    return 56
-  end
-end
-
 ---------- ScreenTitleMenu ----------
 Positions.ScreenTitleMenu = {}
 
@@ -95,4 +69,3 @@ Positions.ScreenTitleMenu.ScrollerY = function()
     return _screen.cy+_screen.h/3.8
   end
 end
-


### PR DESCRIPTION
Also move the difficulty 1px left, which aligns it with the NPS graph, and stops from awkwardly sticking out past the screen filter.

Clean up related positions, because they were created for compatibility with horizontal screens, and that's no longer a goal.