### PR TITLE
Force single player: a crude solution

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/default.lua
@@ -8,6 +8,10 @@ local t = Def.ActorFrame{
 		self:playcommand("StepsHaveChanged", params)
 	end,
 
+	PlayerJoinedMessageCommand=function(self, params)
+		UnjoinLateJoinedPlayer(params.Player)
+	end,
+
 	-- ---------------------------------------------------
 	--  first, load files that contain no visual elements, just code that needs to run
 

--- a/BGAnimations/ScreenSelectPlayMode underlay/default.lua
+++ b/BGAnimations/ScreenSelectPlayMode underlay/default.lua
@@ -10,7 +10,7 @@ local cursor = {
 }
 
 -- the width of the choice_actors multiplied by 0.386 gives us aproximately the width of the text icons
--- we add 30 to have a pretty margin around it 
+-- we add 30 to have a pretty margin around it
 local iconWidthScale = 0.386
 local cursorMargin = 30
 
@@ -64,6 +64,9 @@ local t = Def.ActorFrame{
 			-- and reload the theme's Metrics
 			THEME:ReloadMetrics()
 		end
+	end,
+	PlayerJoinedMessageCommand=function(self, params)
+		UnjoinLateJoinedPlayer(params.Player)
 	end,
 
 	-- lower mask

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -661,3 +661,17 @@ UpdateDefaultGlobalOffset = function()
 	end
 	GAMESTATE:Env()["GlobalOffsetAtSongStart"] = nil
 end
+
+-- -----------------------------------------------------------------------
+-- Unjoins the specified player and displays an error message.
+UnjoinLateJoinedPlayer = function(player)
+	GAMESTATE:UnjoinPlayer(player)
+	-- TODO localize this error message.
+	-- Better yet, find a way to prevent joining altogether, instead of canceling it.
+	-- Known issues with this solution:
+	-- - The wheel scrolls to the first pack/course on join+unjoin
+  -- - The other player's controls remain active (but enter is blocked)
+	-- - Second player name overlaps in the bottom bar
+	-- - On game over screen, both players' stats can sometimes shown
+	SM("Cannot join 2nd player in vertical mode.")
+end


### PR DESCRIPTION
This code unjoins the second (later joined) player if they join on SelectPlayMode or SelectMusic screens. It stops the player from seeing weird UIs like two playfields on top of each other, but it's hacky and has its issues:

- The wheel scrolls to the first pack/course on join+unjoin
- The other player's controls remain active (but enter is blocked)
- Second player name overlaps in the bottom bar
- On game over screen, both players' stats can sometimes shown

Somebody should ~~do something~~ find a way to prevent the second player from even joining. Maybe follow the input handler pattern from ScreenSelectProfile/Input.lua