### PR TITLE
SongSearch no longer creates garbage files for every search

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SongSearch.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongSearch.lua
@@ -1,5 +1,3 @@
-if not THEME:GetMetric("ScreenSelectMusic", "EnableSongSearch") then return end
-
 local wheel
 local screen
 
@@ -59,7 +57,7 @@ t = Def.ActorFrame{
 				-- search. you'll have to use an external tool to clean this folder since
 				-- the theme can't delete files
                                 if #results > 0 then
-                                        filepath = THEME:GetCurrentThemeDirectory().."Other/SongManager "..answer..".txt"
+                                        filepath = THEME:GetCurrentThemeDirectory().."Other/SongManager SearchResults.txt"
                                         f = RageFileUtil.CreateRageFile()
                                         f:Open(filepath, 2) -- 2 = write
                                         f:PutLine("---Search Results") -- folder name
@@ -68,7 +66,7 @@ t = Def.ActorFrame{
                                         end
                                         f:Close()
                                         f:destroy()
-                                        SONGMAN:SetPreferredSongs(answer..".txt")
+                                        SONGMAN:SetPreferredSongs("SearchResults.txt")
                                         wheel:ChangeSort("SortOrder_Preferred")
 					screen:SetNextScreenName("ScreenSelectMusic")
 					screen:StartTransitioningScreen("SM_GoToNextScreen")

--- a/metrics.ini
+++ b/metrics.ini
@@ -1400,13 +1400,13 @@ TimerSeconds=SL.Global.MenuTimer.ScreenSelectMusicCasual
 PrevScreen=Branch.SSMCancel()
 NextScreen=Branch.AfterSelectMusic()
 
-CodeNames="SortList,SortList2,SortList3,EscapeFromEventMode,SongSearch"
+CodeNames="SortList,SortList2,SortList3,EscapeFromEventMode,SongSearch,SongSearch2"
 CodeSortList="@Select-Start"
 CodeSortList2=PREFSMAN:GetPreference("OnlyDedicatedMenuButtons") and "MenuLeft-MenuRight" or GAMESTATE:GetCurrentGame():GetName() == "pump" and "DownLeft-DownRight"
 CodeSortList3=not PREFSMAN:GetPreference("OnlyDedicatedMenuButtons") and "Left-Right" or ""
 CodeEscapeFromEventMode=PREFSMAN:GetPreference("EventMode") and "MenuLeft,MenuLeft,MenuRight,MenuRight,MenuLeft,MenuLeft,MenuRight,MenuRight" or ""
 CodeSongSearch="@Down-Start"
-CodeSongSearch2="@MenuUp-Start"
+CodeSongSearch2="@MenuDown-Start"
 
 
 # this allows us to override the normal sort select command

--- a/metrics.ini
+++ b/metrics.ini
@@ -1397,12 +1397,6 @@ TimerOnCommand=hide_if,not PREFSMAN:GetPreference("MenuTimer");draworder,102;
 TimerSeconds=SL.Global.MenuTimer.ScreenSelectMusicCasual
 
 [ScreenSelectMusic]
-# The song search creates a file in the "Other" folder for every search (Other/SongManager <search terms>.txt)
-# There's no way for the theme to delete this files so you need to use an external tool
-# or manually delete them to avoid filling this folder with the results of old searches
-# Not deleting them can also make this malfunction by showing outdated results for a search after adding new songs
-EnableSongSearch=false
-
 PrevScreen=Branch.SSMCancel()
 NextScreen=Branch.AfterSelectMusic()
 
@@ -1411,7 +1405,7 @@ CodeSortList="@Select-Start"
 CodeSortList2=PREFSMAN:GetPreference("OnlyDedicatedMenuButtons") and "MenuLeft-MenuRight" or GAMESTATE:GetCurrentGame():GetName() == "pump" and "DownLeft-DownRight"
 CodeSortList3=not PREFSMAN:GetPreference("OnlyDedicatedMenuButtons") and "Left-Right" or ""
 CodeEscapeFromEventMode=PREFSMAN:GetPreference("EventMode") and "MenuLeft,MenuLeft,MenuRight,MenuRight,MenuLeft,MenuLeft,MenuRight,MenuRight" or ""
-CodeSongSearch="@Up-Start"
+CodeSongSearch="@Down-Start"
 CodeSongSearch2="@MenuUp-Start"
 
 


### PR DESCRIPTION
It just uses one file instead and overwrites it on every search. I don't know why it works (?)

Now we don't need to use a metric to disable it.
I also changed the shortcut to down+enter so it's harder to open the search thing by mistake.

I'm sleepy so I might be overlooking something because I'm pretty sure what this change does didn't work but now does and I can't find why please make lua stop my brain is not prepared for this.