### PR TITLE
Improved theme pref validation

### DIFF
--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -217,11 +217,13 @@ SL_CustomPrefs.Validate = function()
 	if file[theme_name] then
 		-- loop through key/value pairs retrieved and do some basic validation
 		for k,v in pairs( file[theme_name] ) do
-			if sl_prefs[k] then
+			local pref = sl_prefs[k]
+			if pref then
 				-- if we reach here, the setting exists in both the master definition as well as the user's ThemePrefs.ini
 				-- so perform some rudimentary validation; check for both type mismatch and presence in sl_prefs
-				if type( v ) ~= type( sl_prefs[k].Default )
-				or not FindInTable(v, (sl_prefs[k].Values or sl_prefs[k].Choices))
+				local valid_values = pref.Values or pref.Choices
+				if type( v ) ~= type( pref.Default )
+				or (valid_values and not FindInTable(v, valid_values))
 				then
 					-- overwrite the user's erroneous setting with the default value
 					ThemePrefs.Set(k, sl_prefs[k].Default)

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -212,10 +212,11 @@ SL_CustomPrefs.Validate = function()
 	local file = IniFile.ReadFile("Save/ThemePrefs.ini")
 	local sl_prefs = SL_CustomPrefs.Get()
 
-	-- If a [Simply Love] section is found in ./Save/ThemePrefs.ini
-	if file["Simply Love"] then
+	-- If a section for this theme is found in ./Save/ThemePrefs.ini
+	local theme_name = THEME:GetCurThemeName()
+	if file[theme_name] then
 		-- loop through key/value pairs retrieved and do some basic validation
-		for k,v in pairs( file["Simply Love"] ) do
+		for k,v in pairs( file[theme_name] ) do
 			if sl_prefs[k] then
 				-- if we reach here, the setting exists in both the master definition as well as the user's ThemePrefs.ini
 				-- so perform some rudimentary validation; check for both type mismatch and presence in sl_prefs


### PR DESCRIPTION
- Validate the current theme's options, which might or might not be the "Simply Love" section.
- Don't validate prefs that don't have a known set of valid values beyond having the correct type. Solves the errors that would spam the console since `DefaultGlobalOffsetSeconds` had no `Values` or `Choices`, which would cause `FindInTable(v, (sl_prefs[k].Values or sl_prefs[k].Choices))` to evaluate to `FindInTable(v, nil)`, which Lua understandably doesn't like at all.