### PR TITLE
Fix ScreenPlayerOptions navigation (ArcadeOptionsNavigation) Fixes #43

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -629,7 +629,15 @@ RowPositionTransformFunction=function(self,positionIndex,itemIndex,numItems) sel
 
 RepeatRate=30
 AllowRepeatingChangeValueInput=true
-LineNames="SpeedModType,SpeedMod,Mini,Perspective,NoteSkinSL,Judgment,BackgroundFilter,MusicRate,Stepchart,Hide,LifeMeterType,GameplayExtras,MeasureCounter,MeasureCounterOptions,TimingWindows,ScreenAfterPlayerOptions"
+LineNames=(function() \
+	local lines = "SpeedModType,SpeedMod,Mini,Perspective,NoteSkinSL,Judgment,BackgroundFilter,MusicRate,Stepchart,Hide,LifeMeterType,GameplayExtras,MeasureCounter,MeasureCounterOptions,TimingWindows,ScreenAfterPlayerOptions" \
+	if PREFSMAN:GetPreference("ArcadeOptionsNavigation") == 1 then \
+		lines = lines:gsub(",Hide", "") \
+		lines = lines:gsub(",GameplayExtras,MeasureCounter,MeasureCounterOptions", "") \
+		lines = lines:gsub("Judgment,", "Judgment,ComboFont,HoldJudgment,") \
+	end \
+	return lines \
+end)()
 
 ##### Most Used #####
 # optionrows assembled in ./Scripts/SL-PlayerOptions.lua
@@ -691,7 +699,7 @@ Class="ScreenPlayerOptions"
 Fallback="ScreenPlayerOptions"
 PrevScreen="ScreenPlayerOptions"
 NextScreen=SL.Global.ScreenAfter.PlayerOptions2
-NavigationMode="toggle"
+NavigationMode=PREFSMAN:GetPreference("ArcadeOptionsNavigation") == 1 and "toggle" or "normal"
 
 # remove ActionOnMissedTarget if we're not in EventMode; it doesn't make sense to have it available in a Public Arcade setting
 # remember that removing OptionRows from the modifier menus is only one part of this
@@ -700,6 +708,10 @@ LineNames=(function() \
 	local lines = "ComboFont,HoldJudgment,Turn,Scroll,TargetScore,ActionOnMissedTarget,Insert,Remove,Holds,Mines,11,12,13,Attacks,Characters,GlobalOffsetDelta,ScreenAfterPlayerOptions2" \
 	if GAMESTATE:GetCurrentGame():GetName() == "pump" then lines = lines:gsub("HoldJudgment,","") end \
 	if not PREFSMAN:GetPreference("EventMode") then lines = lines:gsub("ActionOnMissedTarget,", "") end \
+	if PREFSMAN:GetPreference("ArcadeOptionsNavigation") == 1 then \
+		lines = lines:gsub("ComboFont,HoldJudgment,", "") \
+		lines = lines:gsub(",ScreenAfter", ",Hide,GameplayExtras,MeasureCounter,MeasureCounterOptions,ScreenAfter") \
+	end \
     if #CHARMAN:GetAllCharacters() < 1 then lines = lines:gsub("Characters,", "") end \
     return lines \
 end)()

--- a/metrics.ini
+++ b/metrics.ini
@@ -629,6 +629,10 @@ RowPositionTransformFunction=function(self,positionIndex,itemIndex,numItems) sel
 
 RepeatRate=30
 AllowRepeatingChangeValueInput=true
+	# We want to have the most commonly used OptionRows in the first opstions screen,
+	# but due to how NavigationMode affects the behavior of pressing start in ScreenPlayerOptions
+	# the options that need "toggle" need to be in ScreenPlayerOptions2 when ArcadeOptionsNavigation
+	# is set to 1
 LineNames=(function() \
 	local lines = "SpeedModType,SpeedMod,Mini,Perspective,NoteSkinSL,Judgment,BackgroundFilter,MusicRate,Stepchart,Hide,LifeMeterType,GameplayExtras,MeasureCounter,MeasureCounterOptions,TimingWindows,ScreenAfterPlayerOptions" \
 	if PREFSMAN:GetPreference("ArcadeOptionsNavigation") == 1 then \
@@ -704,13 +708,15 @@ NavigationMode=PREFSMAN:GetPreference("ArcadeOptionsNavigation") == 1 and "toggl
 # remove ActionOnMissedTarget if we're not in EventMode; it doesn't make sense to have it available in a Public Arcade setting
 # remember that removing OptionRows from the modifier menus is only one part of this
 # we need to perform additional checks in ./BGA/ScreenGameplay underlay/ to ensure that unwanted modifiers aren't brought into gameplay via player profile
+# Also arrange OptionRows so that when ArcadeOptionsNavigation is set to 1, every OptionRow
+# that needs "toggle" is in ScreenPlayerOptions2
 LineNames=(function() \
 	local lines = "ComboFont,HoldJudgment,Turn,Scroll,TargetScore,ActionOnMissedTarget,Insert,Remove,Holds,Mines,11,12,13,Attacks,Characters,GlobalOffsetDelta,ScreenAfterPlayerOptions2" \
 	if GAMESTATE:GetCurrentGame():GetName() == "pump" then lines = lines:gsub("HoldJudgment,","") end \
 	if not PREFSMAN:GetPreference("EventMode") then lines = lines:gsub("ActionOnMissedTarget,", "") end \
 	if PREFSMAN:GetPreference("ArcadeOptionsNavigation") == 1 then \
 		lines = lines:gsub("ComboFont,HoldJudgment,", "") \
-		lines = lines:gsub(",ScreenAfter", ",Hide,GameplayExtras,MeasureCounter,MeasureCounterOptions,ScreenAfter") \
+		lines = lines:gsub(",ScreenAfterPlayerOptions2", ",Hide,GameplayExtras,MeasureCounter,MeasureCounterOptions,ScreenAfterPlayerOptions2") \
 	end \
     if #CHARMAN:GetAllCharacters() < 1 then lines = lines:gsub("Characters,", "") end \
     return lines \


### PR DESCRIPTION
- Set NavigationMode in ScreenPlayerOptions2 to toggle if ArcadeOptionsNavigation is set to 1 (Arcade style) or normal otherwise (Stepmania style)

- Rearrange optionrows in playeroptions and playeroptions2 so that the optionrows that need NavigationMode set to toggle are in playeroptions2 when ArcadeOptionsNavigation is set to 1

Order or optionrows in playeroptions2 has changed.